### PR TITLE
Handle uninitialized default media receiver

### DIFF
--- a/android/src/main/kotlin/com/felnanuke/google_cast/GoogleCastOptionsProvider.kt
+++ b/android/src/main/kotlin/com/felnanuke/google_cast/GoogleCastOptionsProvider.kt
@@ -7,9 +7,22 @@ import com.google.android.gms.cast.framework.SessionProvider
 
 
  class GoogleCastOptionsProvider : OptionsProvider {
-     companion object{
-         lateinit var options: CastOptions
+     companion object {
+         private var _options: CastOptions? = null
+
+         var options: CastOptions
+             get() = _options ?: defaultOptions()
+             set(value) {
+                 _options = value
+             }
+
+         private fun defaultOptions(): CastOptions {
+             return CastOptions.Builder()
+                 .setReceiverApplicationId("CC1AD845")  // Default Media Receiver
+                 .build()
+         }
      }
+
     override fun getCastOptions(context: Context): CastOptions {
 
         return options

--- a/ios/Classes/SwiftGoogleCastPlugin.swift
+++ b/ios/Classes/SwiftGoogleCastPlugin.swift
@@ -40,7 +40,11 @@ public class SwiftGoogleCastPlugin: NSObject, GCKLoggerDelegate, FlutterPlugin, 
         context.sessionManager.add(FGCSessionManagerMethodChannel.instance)
         context.discoveryManager.startDiscovery()
 
-        result(nil)
+      //this is throwing an error on the flutter side that expects a bool
+      //         result(nil)
+
+      //testing a patch with setting this to true
+      result(true)
     }
 
     // MARK: - GCKLoggerDelegate


### PR DESCRIPTION
Android : sets the default media receiver id (will always be CC1AD845 unless we build a custom receiver)
iOS: removes passing nil to the flutter side of method channel that's causing an exception error.